### PR TITLE
Replace ASCII character with URL-encoded value

### DIFF
--- a/js/external-search.module.js
+++ b/js/external-search.module.js
@@ -40,7 +40,7 @@ angular
         this.$onInit = function () {
           $scope.name = this.parentCtrl.facetGroup.name
           $scope.targets = searchTargets
-          var query = $location.search().query
+          var query = $location.search().query.replace('&', '%26')
           var filter = $location.search().pfilter
           $scope.queries = Object.prototype.toString.call(query) === '[object Array]' ? query : query ? [query] : false
           $scope.filters = Object.prototype.toString.call(filter) === '[object Array]' ? filter : filter ? [filter] : false


### PR DESCRIPTION
Fixes #17 

The ascii character for & may be interpreted as a separation of other url parameters, which would break a query string being passed to external search providers.

Example of issue when viewing GET request:
![image](https://user-images.githubusercontent.com/82611274/232093060-0b77ae48-e669-48c8-9cb2-8d1923662a01.png)
